### PR TITLE
Changed params for data on Token exchange post request

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -9,6 +9,6 @@ if __name__ == "__main__":
     from django.conf import settings
 
     if '--no-migrations' in sys.argv:
-        settings.SOUTH_TESTS_MIGRATE=False
+        settings.SOUTH_TESTS_MIGRATE = False
         sys.argv.remove('--no-migrations')
     execute_from_command_line(sys.argv)

--- a/oidc_auth/auth.py
+++ b/oidc_auth/auth.py
@@ -7,11 +7,11 @@ class OpenIDConnectBackend(object):
     supports_anonymous_user = True
 
     def get_user(self, user_id):
-        UserModel = get_user_model()
+        user_model = get_user_model()
 
         try:
-            return UserModel.objects.get(pk=user_id)
-        except UserModel.DoesNotExist:
+            return user_model.objects.get(pk=user_id)
+        except user_model.DoesNotExist:
             return None
 
     def authenticate(self, **kwargs):
@@ -23,10 +23,11 @@ class OpenIDConnectBackend(object):
             provider = credentials['provider']
             id_token = provider.verify_id_token(credentials['id_token'])
 
-            oidc_user = OpenIDUser.get_or_create(id_token,
-                    credentials['access_token'],
-                    credentials.get('refresh_token', ''),
-                    provider)
+            oidc_user = OpenIDUser.get_or_create(
+                id_token,
+                credentials['access_token'],
+                credentials.get('refresh_token', ''),
+                provider)
 
             return oidc_user.user
         except Exception as e:

--- a/oidc_auth/errors.py
+++ b/oidc_auth/errors.py
@@ -17,14 +17,15 @@ class InvalidIdToken(OpenIDConnectError, ValueError):
 class UnsuppportedSigningMethod(OpenIDConnectError, ValueError):
     def __init__(self, unsupported_method, supported_methods):
         message = 'Signing method %s not supported, options are (%s)' % (
-                unsupported_method, ', '.join(supported_methods))
+            unsupported_method, ', '.join(supported_methods))
 
         super(UnsuppportedSigningMethod, self).__init__(message)
 
 
 class RequestError(OpenIDConnectError):
     def __init__(self, url, status_code):
-        message = 'GET %s returned %s status code (200 expected)' % (url, status_code)
+        message = 'GET %s returned %s status code (200 expected)' %\
+            (url, status_code)
         super(RequestError, self).__init__(message)
 
 
@@ -37,4 +38,5 @@ class ForbiddenAuthRequest(OpenIDConnectError):
 
 
 class MissingRedirectURL(OpenIDConnectError):
-    message = "Missing URL for oidc redirect (maybe DEFAULT_ENDPOINT's missing on settings?)"
+    message = "Missing URL for oidc redirect (maybe DEFAULT_ENDPOINT's missing\
+ on settings?)"

--- a/oidc_auth/forms.py
+++ b/oidc_auth/forms.py
@@ -3,4 +3,5 @@ from django import forms
 
 class OpenIDConnectForm(forms.Form):
     issuer = forms.CharField(max_length=200,
-            widget=forms.TextInput(attrs={'class': 'required openid'}))
+                             widget=forms.TextInput(
+                                 attrs={'class': 'required openid'}))

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -5,7 +5,8 @@ from django.conf import settings
 DEFAULTS = {
     'DISABLE_OIDC': False,
     'DEFAULT_PROVIDER': {},
-    'SCOPES': ('openid', 'given_name', 'family_name', 'preferred_username', 'email'),
+    'SCOPES': ('openid', 'given_name', 'family_name',
+               'preferred_username', 'email'),
     'CLIENT_ID': None,
     'CLIENT_SECRET': None,
     'NONCE_LENGTH': 8,

--- a/oidc_auth/urls.py
+++ b/oidc_auth/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('oidc_auth.views',
-    url(r'^login/$', 'login_begin', name='oidc-login'),
-    url(r'^complete/$', 'login_complete', name='oidc-complete'),
-)
+                       url(r'^login/$', 'login_begin', name='oidc-login'),
+                       url(r'^complete/$', 'login_complete',
+                           name='oidc-complete'),)

--- a/oidc_auth/views.py
+++ b/oidc_auth/views.py
@@ -44,7 +44,7 @@ def _redirect(request, login_complete_view, form_class, redirect_field_name):
     params = urlencode({
         'response_type': 'code',
         'scope': utils.scopes(),
-        # 'redirect_uri': request.build_absolute_uri(reverse(login_complete_view)),
+        'redirect_uri': request.build_absolute_uri(reverse(login_complete_view)),
         'client_id': provider.client_id,
         'state': nonce.state
     })
@@ -75,7 +75,7 @@ def login_complete(request, login_complete_view='oidc-complete',
     provider = nonce.provider
     log.debug('Login started from provider %s' % provider)
 
-    params = {
+    data = {
         'grant_type': 'authorization_code',
         'code': request.GET['code'],
         'redirect_uri': request.build_absolute_uri(reverse(login_complete_view))
@@ -83,7 +83,7 @@ def login_complete(request, login_complete_view='oidc-complete',
 
     response = requests.post(provider.token_endpoint,
                              auth=provider.client_credentials,
-                             params=params, verify=oidc_settings.VERIFY_SSL)
+                             data=data, verify=oidc_settings.VERIFY_SSL)
 
     if response.status_code != 200:
         raise errors.RequestError(provider.token_endpoint, response.status_code)

--- a/settings.py
+++ b/settings.py
@@ -65,7 +65,8 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'urls'
 
 TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
+    # Put strings here, like "/home/html/django_templates" or
+    # "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
 )

--- a/urls.py
+++ b/urls.py
@@ -5,7 +5,6 @@ admin.autodiscover()
 
 
 urlpatterns = patterns('views',
-    url(r'^$', 'index'),
-    url(r'^oidc/', include('oidc_auth.urls')),
-    url(r'^admin/', include(admin.site.urls)),
-)
+                       url(r'^$', 'index'),
+                       url(r'^oidc/', include('oidc_auth.urls')),
+                       url(r'^admin/', include(admin.site.urls)),)

--- a/views.py
+++ b/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import login_required
 def index(request):
     user = request.user
     oidc_account = user.oidc_account
-    message = 'Succesfully logged! Email: %s; sub: %s' % (user, oidc_account.sub)
+    message = 'Succesfully logged! Email: %s; sub: %s' % (user,
+                                                          oidc_account.sub)
 
     return HttpResponse(message)


### PR DESCRIPTION
**This fix allowed me to use django-oidc-auth with Keycloak**
- Changed params for data on Token exchange post request (including change on the params variable to data) and removed comment on # 'redirect_uri': request.build_absolute_uri(reverse(login_complete_view)),

- PEP 8 fix on models.py and views (sorry I can't help it, I'm a PEP8 slave)